### PR TITLE
security cleanup of transitive dependencies

### DIFF
--- a/confluent-sigma/pom.xml
+++ b/confluent-sigma/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <jackson.version>2.14.0-rc1</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
     </properties>
 
     <dependencies>

--- a/confluent-sigma/sigma-streams-ui/Dockerfile
+++ b/confluent-sigma/sigma-streams-ui/Dockerfile
@@ -3,7 +3,9 @@
 
 FROM openjdk:11
 RUN apt-get update && apt-get upgrade -y \
+ && useradd --create-home --shell /bin/bash appuser \
  && rm -rf /var/lib/apt/lists/*
 COPY ./target/sigma-streams-ui-1.2.1.jar /tmp
+USER appuser
 WORKDIR /tmp
 CMD java -jar sigma-streams-ui-1.2.1.jar

--- a/confluent-sigma/sigma-streams-ui/Dockerfile
+++ b/confluent-sigma/sigma-streams-ui/Dockerfile
@@ -2,6 +2,8 @@
 # docker push michaelpeacock/confluent-sigma-regex-ui:latest
 
 FROM openjdk:11
+RUN apt-get update && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 COPY ./target/sigma-streams-ui-1.2.1.jar /tmp
 WORKDIR /tmp
 CMD java -jar sigma-streams-ui-1.2.1.jar

--- a/confluent-sigma/sigma-streams-ui/pom.xml
+++ b/confluent-sigma/sigma-streams-ui/pom.xml
@@ -176,6 +176,13 @@
             <version>1.2.1</version>
             <scope>compile</scope>
         </dependency>
+        <!--  Jackson brings up the latest as of 1/4/2022 Snakeyaml version, however in build process, 1.30 is pulled in. Pinning to fix it  -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.33</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/confluent-sigma/sigma-streams/Dockerfile
+++ b/confluent-sigma/sigma-streams/Dockerfile
@@ -3,8 +3,10 @@
 
 FROM openjdk:11
 RUN apt-get update && apt-get upgrade -y \
- && rm -rf /var/lib/apt/lists/*
+  && useradd --no-log-init --create-home --shell /bin/bash appuser \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY ./target/sigma-streams-1.2.1-fat.jar /tmp
+USER appuser
 WORKDIR /tmp
 CMD java -cp sigma-streams-1.2.1-fat.jar io.confluent.sigmarules.SigmaStreamsApp -c /tmp/config/sigma.properties

--- a/confluent-sigma/sigma-streams/Dockerfile
+++ b/confluent-sigma/sigma-streams/Dockerfile
@@ -2,6 +2,9 @@
 # docker push michaelpeacock/confluent-sigma:v1
 
 FROM openjdk:11
+RUN apt-get update && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY ./target/sigma-streams-1.2.1-fat.jar /tmp
 WORKDIR /tmp
 CMD java -cp sigma-streams-1.2.1-fat.jar io.confluent.sigmarules.SigmaStreamsApp -c /tmp/config/sigma.properties


### PR DESCRIPTION
Updated container build files to include update of system packages Updated jackson-databind version
Pinned snakeyaml to 1.33 - transitive dependency of databind-jackson that was incorrectly imported